### PR TITLE
Fix Uncaught ReferenceError: Pace is not defined

### DIFF
--- a/resources/themes/admin/partials/scripts/footer.blade.php
+++ b/resources/themes/admin/partials/scripts/footer.blade.php
@@ -9,7 +9,7 @@
 <!-- iCheck -->
 {!! Theme::js('plugins/iCheck/icheck.min.js') !!}
 <!-- Pace -->
-{{--{!! Theme::js('plugins/pace/pace.min.js') !!}--}}
+{!! Theme::js('plugins/pace/pace.min.js') !!}
 
 <!-- Jquery BlockUI -->
 {!! Theme::js('plugins/jquery-block-ui/jquery.blockUI.min.js') !!}


### PR DESCRIPTION
Pressing Install button on Modules or Activate button on Themes, triggers the error javascript error: Uncaught ReferenceError: Pace is not defined